### PR TITLE
resolve #31 PDOインスタンスの生成ロジックをFactoryメソッド化する

### DIFF
--- a/app/factory/PdoFactory.php
+++ b/app/factory/PdoFactory.php
@@ -26,6 +26,7 @@ class PdoFactory
         $options = [
             \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
             \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            \PDO::ATTR_PERSISTENT         => true,
         ];
 
         $pdo = new \PDO(

--- a/app/factory/PdoFactory.php
+++ b/app/factory/PdoFactory.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PdoFactory
+ */
+
+namespace App\Factory;
+
+/**
+ * Class PdoFactory
+ *
+ * @package App\Factory
+ */
+class PdoFactory
+{
+
+    /**
+     * PDOインスタンスを生成する
+     *
+     * @return \PDO
+     */
+    public static function create(): \PDO
+    {
+        $dbName = getenv('DB_NAME');
+        $dns = sprintf('mysql:dbname=%s;host=localhost', $dbName);
+
+        $options = [
+            \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ];
+
+        $pdo = new \PDO(
+            $dns,
+            getenv('DB_USER'),
+            getenv('DB_PASSWORD'),
+            $options
+        );
+
+        return $pdo;
+    }
+}

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -28,21 +28,9 @@ class DbTestCase extends TestCase
      */
     public function getConnection()
     {
-        $dotenv = new Dotenv(__DIR__ . '/../');
-        $dotenv->load();
+        $this->pdo = $this->createPdo();
 
-        $dbName = getenv('TEST_DB_NAME');
-        $dns = sprintf('mysql:dbname=%s;host=localhost', $dbName);
-
-        $pdo = new \PDO(
-            $dns,
-            getenv('TEST_DB_USER'),
-            getenv('TEST_DB_PASSWORD')
-        );
-
-        $this->pdo = $pdo;
-
-        return $this->createDefaultDBConnection($pdo);
+        return $this->createDefaultDBConnection($this->pdo);
     }
 
     /**
@@ -58,5 +46,33 @@ class DbTestCase extends TestCase
     protected function getPdo()
     {
         return $this->pdo;
+    }
+
+    /**
+     * テスト用のPDOオブジェクトを生成する
+     *
+     * @return \PDO
+     */
+    private function createPdo()
+    {
+        $dotenv = new Dotenv(__DIR__ . '/../');
+        $dotenv->load();
+
+        $dbName = getenv('TEST_DB_NAME');
+        $dns = sprintf('mysql:dbname=%s;host=localhost', $dbName);
+
+        $options = [
+            \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ];
+
+        $pdo = new \PDO(
+            $dns,
+            getenv('TEST_DB_USER'),
+            getenv('TEST_DB_PASSWORD'),
+            $options
+        );
+
+        return $pdo;
     }
 }


### PR DESCRIPTION
https://github.com/keita-nishimoto/ojt-php/issues/31

PDOインスタンスの生成ロジックをFactoryクラスに分離。

テスト用とオンラインの処理用でメソッドは分割。

PDO::ATTR_ERRMODEやPDO::ATTR_DEFAULT_FETCH_MODE 等の設定も行ってあります。