### PR TITLE
Feature/issue37 仮ユーザー登録の正常系テストケースにDBの中身をassertionするコードを追加

### DIFF
--- a/tests/app/services/PreregistrationScenario/PreregistrationTest.php
+++ b/tests/app/services/PreregistrationScenario/PreregistrationTest.php
@@ -52,6 +52,11 @@ class PreregistrationTest extends DbTestCase
         );
 
         $this->assertSame(
+            false,
+            $preregistration->isRegistered()
+        );
+
+        $this->assertSame(
             $email,
             $preregistration->getEmail()
         );
@@ -68,13 +73,15 @@ class PreregistrationTest extends DbTestCase
         );
 
         $expectedPreregistrations = [
-            'id'           => '2',
-            'lock_version' => '0',
+            'id'            => '2',
+            'is_registered' => '0',
+            'lock_version'  => '0',
         ];
 
         $actualPreregistrations = [
-            'id'           => $preregistrationsQueryTable->getValue(1, 'id'),
-            'lock_version' => $preregistrationsQueryTable->getValue(1, 'lock_version'),
+            'id'            => $preregistrationsQueryTable->getValue(1, 'id'),
+            'is_registered' => $preregistrationsQueryTable->getValue(1, 'is_registered'),
+            'lock_version'  => $preregistrationsQueryTable->getValue(1, 'lock_version'),
         ];
 
         $this->assertSame($expectedPreregistrations, $actualPreregistrations);

--- a/tests/app/services/PreregistrationScenario/PreregistrationTest.php
+++ b/tests/app/services/PreregistrationScenario/PreregistrationTest.php
@@ -42,7 +42,19 @@ class PreregistrationTest extends DbTestCase
             ['email' => $email]
         );
 
+        // 意図した通りのドメインオブジェクトが返却される事を確認する
         $this->assertInstanceOf('\\App\\Models\\Domain\\Preregistration', $preregistration);
+
+        // 各属性が意図した値かどうかを確認
+        $this->assertSame(
+            2,
+            $preregistration->getId()
+        );
+
+        $this->assertSame(
+            $email,
+            $preregistration->getEmail()
+        );
 
         // 仮ユーザー登録のテーブルが意図した通りに変わっているか確認する
         $this->assertEquals(

--- a/tests/app/services/PreregistrationScenario/PreregistrationTest.php
+++ b/tests/app/services/PreregistrationScenario/PreregistrationTest.php
@@ -41,5 +41,33 @@ class PreregistrationTest extends DbTestCase
         );
 
         $this->assertInstanceOf('\\App\\Models\\Domain\\Preregistration', $preregistration);
+
+        // テーブルの件数が意図した通りに変わっているかを確認
+        $this->assertEquals(
+            2,
+            $this->getConnection()->getRowCount('preregistrations_tokens')
+        );
+
+        $queryTable = $this->getConnection()->createQueryTable(
+            'preregistrations_tokens',
+            'SELECT * FROM preregistrations_tokens'
+        );
+
+        // テーブルの中身が意図した通りに変わっているかを確認
+        $expectedPreregistrationsTokens = [
+            'id'           => '2',
+            'register_id'  => '2',
+            'token'        => $preregistration->getToken(),
+            'lock_version' => '0',
+        ];
+
+        $actualPreregistrationsTokens = [
+            'id'           => $queryTable->getValue(1, 'id'),
+            'register_id'  => $queryTable->getValue(1, 'register_id'),
+            'token'        => $queryTable->getValue(1, 'token'),
+            'lock_version' => $queryTable->getValue(1, 'lock_version'),
+        ];
+
+        $this->assertSame($expectedPreregistrationsTokens, $actualPreregistrationsTokens);
     }
 }

--- a/tests/app/services/PreregistrationScenario/PreregistrationTest.php
+++ b/tests/app/services/PreregistrationScenario/PreregistrationTest.php
@@ -37,6 +37,10 @@ class PreregistrationTest extends DbTestCase
         $preregistrationScenario = new PreregistrationScenario($pdo);
 
         $email = 'keita.koga.work+1@gmail.com';
+        $nowDate = $expectedExpiredOn = new \DateTime();
+
+        $expectedExpiredOn = new \DateTime();
+        $expectedExpiredOn->add(new \DateInterval('P1D'));
 
         $preregistration = $preregistrationScenario->preregistration(
             ['email' => $email]
@@ -57,6 +61,11 @@ class PreregistrationTest extends DbTestCase
         );
 
         $this->assertSame(
+            $expectedExpiredOn->format('Y-m-d'),
+            $preregistration->getExpiredOn()->format('Y-m-d')
+        );
+
+        $this->assertSame(
             $email,
             $preregistration->getEmail()
         );
@@ -72,16 +81,28 @@ class PreregistrationTest extends DbTestCase
             'SELECT * FROM preregistrations'
         );
 
+        $expectedCreatedAt = new \DateTime(
+            $preregistrationsQueryTable->getValue(1, 'created_at')
+        );
+
+        $expectedUpdatedAt = new \DateTime(
+            $preregistrationsQueryTable->getValue(1, 'updated_at')
+        );
+
         $expectedPreregistrations = [
             'id'            => '2',
             'is_registered' => '0',
             'lock_version'  => '0',
+            'created_at'    => $nowDate->format('Y-m-d'),
+            'updated_at'    => $nowDate->format('Y-m-d'),
         ];
 
         $actualPreregistrations = [
             'id'            => $preregistrationsQueryTable->getValue(1, 'id'),
             'is_registered' => $preregistrationsQueryTable->getValue(1, 'is_registered'),
             'lock_version'  => $preregistrationsQueryTable->getValue(1, 'lock_version'),
+            'created_at'    => $expectedCreatedAt->format('Y-m-d'),
+            'updated_at'    => $expectedUpdatedAt->format('Y-m-d'),
         ];
 
         $this->assertSame($expectedPreregistrations, $actualPreregistrations);
@@ -102,13 +123,25 @@ class PreregistrationTest extends DbTestCase
             'register_id'  => '2',
             'token'        => $preregistration->getToken(),
             'lock_version' => '0',
+            'created_at'   => $nowDate->format('Y-m-d'),
+            'updated_at'   => $nowDate->format('Y-m-d'),
         ];
+
+        $expectedCreatedAt = new \DateTime(
+            $preregistrationsTokensQueryTable->getValue(1, 'created_at')
+        );
+
+        $expectedUpdatedAt = new \DateTime(
+            $preregistrationsTokensQueryTable->getValue(1, 'updated_at')
+        );
 
         $actualPreregistrationsTokens = [
             'id'           => $preregistrationsTokensQueryTable->getValue(1, 'id'),
             'register_id'  => $preregistrationsTokensQueryTable->getValue(1, 'register_id'),
             'token'        => $preregistrationsTokensQueryTable->getValue(1, 'token'),
             'lock_version' => $preregistrationsTokensQueryTable->getValue(1, 'lock_version'),
+            'created_at'   => $expectedCreatedAt->format('Y-m-d'),
+            'updated_at'   => $expectedUpdatedAt->format('Y-m-d'),
         ];
 
         $this->assertSame($expectedPreregistrationsTokens, $actualPreregistrationsTokens);
@@ -129,13 +162,25 @@ class PreregistrationTest extends DbTestCase
             'register_id'  => '2',
             'token'        => $email,
             'lock_version' => '0',
+            'created_at'   => $nowDate->format('Y-m-d'),
+            'updated_at'   => $nowDate->format('Y-m-d'),
         ];
+
+        $expectedCreatedAt = new \DateTime(
+            $preregistrationsEmailsQueryTable->getValue(1, 'created_at')
+        );
+
+        $expectedUpdatedAt = new \DateTime(
+            $preregistrationsEmailsQueryTable->getValue(1, 'updated_at')
+        );
 
         $actualPreregistrationsEmails = [
             'id'           => $preregistrationsEmailsQueryTable->getValue(1, 'id'),
             'register_id'  => $preregistrationsEmailsQueryTable->getValue(1, 'register_id'),
             'token'        => $preregistrationsEmailsQueryTable->getValue(1, 'email'),
             'lock_version' => $preregistrationsEmailsQueryTable->getValue(1, 'lock_version'),
+            'created_at'   => $expectedCreatedAt->format('Y-m-d'),
+            'updated_at'   => $expectedUpdatedAt->format('Y-m-d'),
         ];
 
         $this->assertSame($expectedPreregistrationsEmails, $actualPreregistrationsEmails);


### PR DESCRIPTION
https://github.com/keita-nishimoto/ojt-php/issues/37

[こちら](https://phpunit.de/manual/current/ja/database.html) ではアサーションにフラットXMLを利用しているか本プロジェクトでは利用しない。

トークン等の動的に生成する値をアサートする時に扱いにくい為である。

